### PR TITLE
Add backwards-compatibility ocamlfind subpackages

### DIFF
--- a/META.xenstore_transport.template
+++ b/META.xenstore_transport.template
@@ -1,0 +1,11 @@
+# JBUILDER_GEN
+
+package "unix" (
+  description = "Deprecated. Use xenstore_transport"
+  requires = "xenstore_transport"
+)
+
+package "lwt" (
+  description = "Deprecated. Use xenstore_transport"
+  requires = "xenstore_transport"
+)


### PR DESCRIPTION
As part of the jbuilder converstion, the packages

- `xenstore_transport`
- `xenstore_transport.unix`
- `xenstore_transport.lwt`

were merged into `xenstore_transport`. This patch adds aliases to the
META file so we don't needlessly break the build of other components
which try to link with the subpackage.

This fixes the build of packages like vhd-tool, see
https://github.com/ocaml/opam-repository/pull/9481#issuecomment-307814311

Signed-off-by: David Scott <dave@recoil.org>