### PR TITLE
Packaging fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ build:
 	jbuilder build @install --dev
 
 test:
-	jbuilder runtest
+	jbuilder build --dev test/client_test.exe
+	jbuilder build --dev test/server_test.exe
 
 install:
 	jbuilder install

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,6 +1,6 @@
 (library
  ((name xenstore_transport)
   (public_name xenstore_transport)
-  (libraries (lwt xenstore xenstore.client))
+  (libraries (lwt.unix xenstore xenstore.client))
   (wrapped false)
 ))

--- a/test/server_test.ml
+++ b/test/server_test.ml
@@ -91,7 +91,7 @@ let make_connection id =
   let ps = PS.make c in
   {id; ps}
 
-let rpc ?(verbose=true) store c tid payload =
+let rpc ?(verbose=true) _store c tid payload =
   let request = Xs_protocol.Request.print payload tid 0l in
   if verbose then Printf.printf "[%d,%ld,req] %s\n" c.id tid (Xs_protocol.Request.prettyprint request);
   (* send request *)
@@ -121,9 +121,9 @@ let empty_store () =
   let c = make_connection (-1) in
   let store = () in
   let open Xs_protocol.Request in
-  rpc ~verbose:false store c none (PathOp("/a", Rm));
-  rpc ~verbose:false store c none (PathOp("/bench", Rm));
-  rpc ~verbose:false store c none (PathOp("/foo", Rm));
+  ignore @@ rpc ~verbose:false store c none (PathOp("/a", Rm));
+  ignore @@ rpc ~verbose:false store c none (PathOp("/bench", Rm));
+  ignore @@ rpc ~verbose:false store c none (PathOp("/foo", Rm));
   ()
 
 


### PR DESCRIPTION
Because of this, `vchan.0.9.6` is not compiling anymore and fails with:

```
- + /home/samoht/.opam/4.03.0/bin/ocamlfind ocamlopt -linkpkg -g -I lib -linkpkg -package xenstore_transport.lwt -package xenstore_transport -package xenstore.client -package xenstore -package xen-gnt.unix -package xen-gnt -package xen-evtchn.unix.activations -package xen-evtchn.unix -package xen-evtchn -package mirage-types.lwt -package lwt -package io-page.unix -package io-page -package cstruct.syntax -package cstruct -package cmdliner -I lib -I cli lib/vchan.cmxa cli/node_cli.cmx -o cli/node_cli.native
- File "_none_", line 1:
- Error: No implementations provided for the following modules:
-          Lwt_unix referenced from /home/samoht/.opam/4.03.0/lib/xenstore_transport/xenstore_transport.cmxa(Xs_transport_lwt_unix_client)
```