### PR TITLE
Set spdx license identifiers for LGPL 2.1 only in opam files

### DIFF
--- a/xenstore-tool.opam
+++ b/xenstore-tool.opam
@@ -12,7 +12,7 @@ authors: [
   "Thomas Sanders"
   "Vincent Bernardoff"
 ]
-license: "LGPL"
+license: "LGPL-2.1-only"
 tags: ["org:mirage" "org:xapi-project"]
 homepage: "http://github.com/xapi-project/ocaml-xenstore-clients"
 doc: "http://xapi-project.github.io/ocaml-xenstore-clients/"

--- a/xenstore_transport.opam
+++ b/xenstore_transport.opam
@@ -12,7 +12,7 @@ authors: [
   "Thomas Sanders"
   "Vincent Bernardoff"
 ]
-license: "LGPL"
+license: "LGPL-2.1-only"
 tags: ["org:mirage" "org:xapi-project"]
 homepage: "http://github.com/xapi-project/ocaml-xenstore-clients"
 doc: "http://xapi-project.github.io/ocaml-xenstore-clients"


### PR DESCRIPTION
As I understand it, this library is not licensed under the LGPL 2.1
_or any later version_, but under the version 2.1 only.

opam defaults to LGPL 2.1 or later if the identifier "LGPL" is given, so
it makes sense to fix this being displayed erroneously on opam.ocaml.org
for future releases.