### PR TITLE
Handle building with latest `ocaml-xenstore`

### DIFF
--- a/cli/xs_client_cli.ml
+++ b/cli/xs_client_cli.ml
@@ -157,7 +157,7 @@ let usage () =
       "";
       "Usage:";
       bin
-        " [-path /var/run/xenstored/socket] [-restrict domid] <subcommand> \
+        " [-path /var/run/xenstored/socket] <subcommand> \
          [args]";
       "";
       "Where <subcommand> can be one of:";
@@ -218,22 +218,14 @@ let main () =
     (match path with
     | Some path -> Xs_transport.xenstored_socket := path
     | None -> ());
-    let restrict_domid, args = extract args "-restrict" in
-    let do_restrict xs =
-      match restrict_domid with
-      | Some domid -> restrict xs (int_of_string domid)
-      | None -> return ()
-    in
     match args with
     | [ "read"; key ] ->
         make () >>= fun client ->
         immediate client (fun xs ->
-            do_restrict xs >>= fun () ->
             read xs key >>= fun v -> Lwt_io.write Lwt_io.stdout v)
     | [ "directory"; key ] ->
         make () >>= fun client ->
         immediate client (fun xs ->
-            do_restrict xs >>= fun () ->
             directory xs key >>= fun ls ->
             Lwt_list.iter_s (fun x -> Lwt_io.write Lwt_io.stdout (x ^ "\n")) ls)
     | "write" :: expr ->
@@ -252,12 +244,10 @@ let main () =
         >>= fun items ->
         make () >>= fun client ->
         immediate client (fun xs ->
-            do_restrict xs >>= fun () ->
             Lwt_list.iter_s (fun (k, v) -> write xs k v) items)
     | "debug" :: cmd_args ->
         make () >>= fun client ->
         immediate client (fun xs ->
-            do_restrict xs >>= fun () ->
             debug xs cmd_args >>= fun results ->
             Lwt_list.iter_s
               (fun x -> Lwt_io.write Lwt_io.stdout (x ^ "\n"))
@@ -271,7 +261,6 @@ let main () =
             make () >>= fun client ->
             let result =
               wait client (fun xs ->
-                  do_restrict xs >>= fun () ->
                   eval_expression expr xs >>= fun result ->
                   if not result then fail Eagain else return ())
             in

--- a/test/server_test.ml
+++ b/test/server_test.ml
@@ -261,25 +261,6 @@ let test_rm () =
     ]
 
 (*
-let test_restrict () =
-	(* Check that only dom0 can restrict to another domain
-	   and that it loses access to dom0-only nodes. *)
-	let dom0 = Connection.create (Xs_protocol.Domain 0) None in
-	let dom3 = Connection.create (Xs_protocol.Domain 3) None in
-	let dom7 = Connection.create (Xs_protocol.Domain 7) None in
-	let store = empty_store () in
-	let open Xs_protocol.Request in
-	run store [
-		dom0, none, PathOp("/foo", Write "bar"), OK;
-		dom0, none, PathOp("/foo", Setperms example_acl), OK;
-		dom3, none, PathOp("/foo", Write "bar"), OK;
-		dom7, none, PathOp("/foo", Write "bar"), Err "EACCES";
-		dom0, none, Restrict 7, OK;
-		dom0, none, PathOp("/foo", Write "bar"), Err "EACCES";
-	]
-*)
-
-(*
 let test_set_target () =
 	(* Check that dom0 can grant dom1 access to dom2's nodes,
 	   without which it wouldn't have access. *)
@@ -844,7 +825,6 @@ let _ =
            "test_mkdir" >:: test_mkdir;
            "test_empty" >:: test_empty;
            "test_rm" >:: test_rm;
-           (*		"test_restrict" >:: test_restrict;*)
            (*		"test_set_target" >:: test_set_target;*)
            "transactions_are_isolated" >:: test_transactions_are_isolated;
            "independent_transactions_coalesce"


### PR DESCRIPTION
`ocaml-xenstore` [finally removed](https://github.com/mirage/ocaml-xenstore/pull/55) long-deprecated `restrict`, drop it here as well.